### PR TITLE
fix loading animation

### DIFF
--- a/www/html/css/events.css
+++ b/www/html/css/events.css
@@ -43,7 +43,7 @@ a:hover{
     overflow-x:auto;
 }
 .eventsContainer{
-    display: flex;
+    display: none;
     flex-flow:row wrap;
     justify-content:flex-start space-evenly;
     align-items:flex-start;

--- a/www/html/css/loading.css
+++ b/www/html/css/loading.css
@@ -61,6 +61,7 @@
     display: flex;
 }
 #loading{
+  display: none;
   opacity: 1;
   -webkit-transition: opacity 1900ms linear;
   transition: opacity 1900ms linear;

--- a/www/html/js/loading.js
+++ b/www/html/js/loading.js
@@ -3,6 +3,14 @@ function changeClass(el,cls){
 }
 function fade(el,opacity){
     e = document.getElementById(el);
+    if (opacity > 0){
+        if (el == 'container'){
+            e.style.display = "flex";
+        }
+        else{
+            e.style.display = "block";
+        }
+    }
     e.style.opacity = opacity;
 }
 function remove(el){


### PR DESCRIPTION
- Container DIV would show through animation if a link was clicked without refreshing page.
  - added display: none to events.css .eventsContainer
  - added display: none to loading.css #container
  - modified function fade to check if opacity is set to a non zero value
  - if element id is 'container' then set container display to flex
  - if element id is anything but 'container' then set display to block.