### PR TITLE
fix ref before assignment error

### DIFF
--- a/app/setup.py
+++ b/app/setup.py
@@ -196,9 +196,13 @@ def setupAddMqttPost():
                 elif field == "user":
                     if "none" in fields[field]:
                         user=""
+                    else:
+                        user = brokerU
                 elif field == "password":
                     if "none" in fields[field]:
                         password=""
+                    else:
+                        password = brokerP
         if Valid:
             MQTT = mqtt(port=port,topics=topics,user=user,password=password,https=https,fevr=fevr,broker=broker,key=key)
             db.session.add(MQTT)


### PR DESCRIPTION
This fixes the issue in mqtt setup where when using a user and/or password to connect to broker it would throw a 'referenced before assignment' error.